### PR TITLE
added EmailClient

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+local_config.conf
+
 target/
 
 .settings

--- a/build.sbt
+++ b/build.sbt
@@ -9,6 +9,8 @@ lazy val akkaVersion = "2.6.14"
 libraryDependencies ++= Seq(
   "com.typesafe.akka" %% "akka-actor-typed" % akkaVersion,
   "ch.qos.logback" % "logback-classic" % "1.2.3",
+  "org.apache.commons" % "commons-email" % "1.5",
+  "com.typesafe" % "config" % "1.4.1",
   "com.typesafe.akka" %% "akka-actor-testkit-typed" % akkaVersion % Test,
   "org.scalatest" %% "scalatest" % "3.1.0" % Test
 )

--- a/src/main/resources/application.conf
+++ b/src/main/resources/application.conf
@@ -1,0 +1,13 @@
+email {
+    hostName : smtp.googlemail.com
+    smtpPort : 465
+    SSLOnConnect : true
+
+    from : ${localConfig.email.from}
+    authenticator {
+        userName : ${localConfig.email.authenticator.userName}
+        password : ${localConfig.email.authenticator.password}
+    }
+}
+
+include "local_config.conf"

--- a/src/main/scala/org/dedkot/EmailApp.scala
+++ b/src/main/scala/org/dedkot/EmailApp.scala
@@ -1,0 +1,5 @@
+package org.dedkot
+
+object EmailApp extends App {
+  EmailClient.sendSimpleMsg("Test", "Test", "themordreid@gmail.com")
+}

--- a/src/main/scala/org/dedkot/EmailClient.scala
+++ b/src/main/scala/org/dedkot/EmailClient.scala
@@ -3,11 +3,15 @@ package org.dedkot
 import com.typesafe.config.ConfigFactory
 import org.apache.commons.mail.{DefaultAuthenticator, SimpleEmail}
 
+/** Singleton object. Implements sending email messages.
+ *
+ * Configurable in application.conf.
+ */
 object EmailClient {
 
-  val conf = ConfigFactory.load()
+  private val conf = ConfigFactory.load()
 
-  val email = new SimpleEmail()
+  private val email = new SimpleEmail()
 
   email.setHostName(conf.getString("email.hostName"))
   email.setSmtpPort(conf.getInt("email.smtpPort"))
@@ -17,6 +21,13 @@ object EmailClient {
     conf.getString("email.authenticator.password")))
   email.setFrom(conf.getString("email.from"))
 
+  /** Sends the simple email.
+   *
+   *  @param subject the email subject.
+   *  @param text define the content of the mail.
+   *  @param destinationEmail add a recipient TO to the email.
+   *  @return the message id of the underlying MimeMessage.
+   */
   def sendSimpleMsg(subject: String, text: String, destinationEmail: String): String = {
     email.setSubject(subject)
       .setMsg(text)

--- a/src/main/scala/org/dedkot/EmailClient.scala
+++ b/src/main/scala/org/dedkot/EmailClient.scala
@@ -1,0 +1,27 @@
+package org.dedkot
+
+import com.typesafe.config.ConfigFactory
+import org.apache.commons.mail.{DefaultAuthenticator, SimpleEmail}
+
+object EmailClient {
+
+  val conf = ConfigFactory.load()
+
+  val email = new SimpleEmail()
+
+  email.setHostName(conf.getString("email.hostName"))
+  email.setSmtpPort(conf.getInt("email.smtpPort"))
+  email.setSSLOnConnect(conf.getBoolean("email.SSLOnConnect"))
+  email.setAuthenticator(new DefaultAuthenticator(
+    conf.getString("email.authenticator.userName"),
+    conf.getString("email.authenticator.password")))
+  email.setFrom(conf.getString("email.from"))
+
+  def sendSimpleMsg(subject: String, text: String, destinationEmail: String): String = {
+    email.setSubject(subject)
+      .setMsg(text)
+      .addTo(destinationEmail)
+      .send
+  }
+
+}


### PR DESCRIPTION
Реализована отправка обычных сообщений: тема и текст сообщения.

Использовались org.apache.commons.commons-email 1.5 и com.typesafe.config 1.4.1.